### PR TITLE
Add Labels and Colours to Forums

### DIFF
--- a/db/migrate/20240821000000_add_label_and_colour_to_forums.rb
+++ b/db/migrate/20240821000000_add_label_and_colour_to_forums.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddLabelAndColourToForums < ActiveRecord::Migration[6.0]
+  def change
+    add_column :forums, :label, :string, limit: 100
+    add_column :forums, :colour, :string, limit: 20
+  end
+end


### PR DESCRIPTION
This pull request introduces the ability to add labels and colours to forums. A new migration has been created to add two columns: `label` (string, limit 100) and `colour` (string, limit 20) to the `forums` table. This enhancement will allow for better categorization and visual differentiation of forums, improving user experience.

---

> This pull request was co-created with Cosine Genie

Original Task: [discourse/cvazs2k3z7vp](https://cosine.sh/cosinedemo/discourse/task/cvazs2k3z7vp)
Author: Pandelis Zembashis
