### PR TITLE
Enhance Login Components for OpenID Connect Providers

### DIFF
--- a/app/assets/javascripts/discourse/app/models/login-method.js
+++ b/app/assets/javascripts/discourse/app/models/login-method.js
@@ -30,7 +30,12 @@ export default class LoginMethod extends EmberObject {
 
   @discourseComputed
   title() {
-    return this.title_override || i18n(`login.${this.name}.title`);
+    // Prefer explicit override, then i18n, then pretty name, finally a humanized provider name.
+    const fallback = this.prettyName || this.name?.toString().replace(/_/g, " ");
+    return (
+      this.title_override ||
+      i18n(`login.${this.name}.title`, { defaultValue: fallback })
+    );
   }
 
   @discourseComputed
@@ -43,7 +48,13 @@ export default class LoginMethod extends EmberObject {
 
   @discourseComputed
   prettyName() {
-    return this.pretty_name_override || i18n(`login.${this.name}.name`);
+    // Prefer explicit override, then i18n, and finally a humanized provider name.
+    return (
+      this.pretty_name_override ||
+      i18n(`login.${this.name}.name`, {
+        defaultValue: this.name?.toString().replace(/_/g, " "),
+      })
+    );
   }
 
   doLogin({ reconnect = false, signup = false, params = {} } = {}) {


### PR DESCRIPTION
This pull request updates the login components to support multiple OpenID Connect providers. The `title` and `prettyName` methods in the `LoginMethod` class have been modified to prefer explicit overrides for titles, followed by internationalized names, and then human-readable names where applicable. This enhancement improves the display for various login methods, ensuring a better user experience when integrating with different OpenID Connect providers.

---

> This pull request was co-created with Cosine Genie

Original Task: [discourse/rufum6tqbmwk](https://cosine.sh/cosinedemo/discourse/task/rufum6tqbmwk)
Author: Pandelis Zembashis
